### PR TITLE
Update of down sampling, partial hanning taper, rescale ccf, and allow device with mps

### DIFF
--- a/cctorch/model.py
+++ b/cctorch/model.py
@@ -73,7 +73,7 @@ class CCModel(nn.Module):
                     - data (torch.Tensor): data2 with shape (batch, nsta/nch, nt)
                     - info (dict): information information of data2
         """
-        self.window = self.partial_hann_taper(self.nfft, 0.04)
+        self.window = self.partial_hann_taper(self.nfft, 0.04, device=self.device)
         x1, x2 = x
         if self.to_device:
             data1 = x1["data"].to(self.device)

--- a/run.py
+++ b/run.py
@@ -1,6 +1,8 @@
+import os
+os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
+
 import json
 import logging
-import os
 import threading
 from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 from dataclasses import dataclass


### PR DESCRIPTION
1. read_mseed can get --sampling_rate and do downsample now
2. do demean before pad zeros to get one day length, or the padded zeros will be shifted after the later demean.
3. comment nt=8640001, or the tensor from "data = np.zeros([3, nx, nt], dtype=np.float32)" will create data length before downsampling instead of the data length after downsampling.
4. apply "partial_hann_taper" to replace the hann_window.
5. ccf îs devided by window length after cross-correlation now.
6. In run.py, add _os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"_ to allow --device=mps.